### PR TITLE
Add option to keep timestamp visible.

### DIFF
--- a/SliderControl.js
+++ b/SliderControl.js
@@ -139,7 +139,7 @@ L.Control.SliderControl = L.Control.extend({
             }
         });
         if (!_options.range && _options.alwaysShowDate) {
-            $('#slider-timestamp').html(_options.markers[24].feature.properties.time.substr(0, 19));
+            $('#slider-timestamp').html(_options.markers[_options.minValue].feature.properties.time.substr(0, 19));
         }
         _options.map.addLayer(_options.markers[_options.minValue]);
     }

--- a/SliderControl.js
+++ b/SliderControl.js
@@ -6,7 +6,8 @@ L.Control.SliderControl = L.Control.extend({
         minValue: -1,
         markers: null,
         range: false,
-        follow: false
+        follow: false,
+        alwaysShowDate : false
     },
 
     initialize: function (options) {
@@ -43,8 +44,10 @@ L.Control.SliderControl = L.Control.extend({
         });
         $(document).mouseup(function () {
             map.dragging.enable();
-            //Only show the slider timestamp while using the slider
-            $('#slider-timestamp').html('');
+            //Hide the slider timestamp if not range and option alwaysShowDate is set on false
+            if (options.range || !options.alwaysShowDate) {
+                $('#slider-timestamp').html('');
+            }
         });
 
         var options = this.options;
@@ -135,6 +138,9 @@ L.Control.SliderControl = L.Control.extend({
                 }
             }
         });
+        if (!_options.range && _options.alwaysShowDate) {
+            $('#slider-timestamp').html(_options.markers[24].feature.properties.time.substr(0, 19));
+        }
         _options.map.addLayer(_options.markers[_options.minValue]);
     }
 });


### PR DESCRIPTION
Here is a little modification I suggest.
Original version allows only to display timestamp only when the slider is active. I made small changes to make it possible to keep it displaying all the time.
As it wouldn't be logical to display one timestamp when it's a range. I made the 'range=false' have priority over "alwaysShowDate=true".

Here is a demo = http://kara.62.free.fr/slider_alwaysshowtimestamp/?range=false&alwaysShowDate=true
You can change values of range et alwaysShowDate directly in the URL.

Also, I would like to ask you about your plugin. In the context of a school project, 3 people and I are trying to improve Leaflet and its existing plugins. Yours is interesting and I have some others suggestions to work on. Would you accept if I continue pull requesting changes? (if you want to answer by mail : julien@soret.in ). Danke schön!