### PR TITLE
Fix markers array's indexes and slider bounds

### DIFF
--- a/SliderControl.js
+++ b/SliderControl.js
@@ -3,7 +3,7 @@ L.Control.SliderControl = L.Control.extend({
         position: 'topright',
         layers: null,
         maxValue: -1,
-        minValue: -1,
+        minValue: 0,
         markers: null,
         range: false,
         follow: false
@@ -52,13 +52,12 @@ L.Control.SliderControl = L.Control.extend({
 
         //If a layer has been provided: calculate the min and max values for the slider
         if (this._layer) {
+            var index_temp = 0;
             this._layer.eachLayer(function (layer) {
-                if (options.minValue === -1) {
-                    options.minValue = layer._leaflet_id;
-                }
-                options.maxValue = layer._leaflet_id;
-                options.markers[layer._leaflet_id] = layer;
+                options.markers[index_temp] = layer;
+                ++index_temp;
             });
+            options.maxValue = index_temp - 1;
             this.options = options;
         } else {
             console.log("Error: You have to specify a layer via new SliderControl({layer: your_layer});");
@@ -78,9 +77,9 @@ L.Control.SliderControl = L.Control.extend({
         _options = this.options;
         $("#leaflet-slider").slider({
             range: _options.range,
-            value: _options.minValue + 1,
+            value: _options.minValue,
             min: _options.minValue,
-            max: _options.maxValue +1,
+            max: _options.maxValue,
             step: 1,
             slide: function (e, ui) {
                 var map = _options.map;


### PR DESCRIPTION
The problem was
The slider first step was the first marker. But the next step didn't display any. ( mentioned here : https://github.com/dwilhelm89/LeafletSlider/issues/20 )
That's because the indexes of the options.markers[ ] are 24 to 24+X (with X=markers number) but with 25 empty. 
I changed it to 0 to X-1 like a normal array by incrementing a variable. No hole in the array anymore.

Current version : http://kara.62.free.fr/slider_fixbounds/old.html
Demo with fix : http://kara.62.free.fr/slider_fixbounds/