### PR TITLE
Fixes a bug for initial showing of date when alwaysShowDate is true…

### DIFF
--- a/SliderControl.js
+++ b/SliderControl.js
@@ -180,7 +180,22 @@ L.Control.SliderControl = L.Control.extend({
             }
         });
         if (!_options.range && _options.alwaysShowDate) {
-            $('#slider-timestamp').html(_extractTimeStamp(_options.markers[index_start].feature.properties[_options.timeAttribute], _options));
+	    if(_options.markers[index_start].feature !== undefined) {
+		if(_options.markers[index_start].feature.properties[_options.timeAttribute]){
+		    if(_options.markers[index_start]) $('#slider-timestamp').html(
+                                _extractTimestamp(_options.markers[index_start].feature.properties[_options.timeAttribute], _options));
+		}else {
+		    console.error("Time property "+ _options.timeAttribute +" not found in data");
+		}
+	    }else {
+		// set by leaflet Vector Layers
+		if(_options.markers [index_start].options[_options.timeAttribute]){
+		    if(_options.markers[index_start]) $('#slider-timestamp').html(
+				_extractTimestamp(_options.markers[index_start].options[_options.timeAttribute], _options));
+		}else {
+		    console.error("Time property "+ _options.timeAttribute +" not found in data");
+		}
+	    }
         }
         for (i = _options.minValue; i <= index_start; i++) {
             _options.map.addLayer(_options.markers[i]);


### PR DESCRIPTION
…AND non-marker layers are displayed.

There are actually two bug fixes here:
1) _extractTimeStamp should be _extractTimestamp
2) When the slider is showing layers over time (rather than markers), the single line of code in 183 doesn't work.  This patch copies the logic from above.

A better fix would be to refactor the code so that the timestamp updating logic only occurs once in the code, but this seems to be a bit tricky given how the slider is set up.